### PR TITLE
Fix video embed rendering on published pages

### DIFF
--- a/public/admin/index.html
+++ b/public/admin/index.html
@@ -132,7 +132,7 @@
             required: false,
           },
         ],
-        pattern: /{{< video "([^"]+)"(?:\s+"([^"]*)")? >}}/,
+        pattern: /{{< video ["“”]([^"“”]+)["“”](?:\s+["“”]([^"“”]*)["“”])? >}}/,
         fromBlock: function (match) {
           return { url: match[1], title: match[2] || '' };
         },

--- a/public/admin/preview.css
+++ b/public/admin/preview.css
@@ -235,7 +235,7 @@ hr {
 }
 
 /* ── Video embed ── */
-.youtube-embed {
+.video-embed {
   position: relative;
   width: 100%;
   aspect-ratio: 16 / 9;
@@ -244,7 +244,7 @@ hr {
   overflow: hidden;
   background-color: var(--color-surface);
 }
-.youtube-embed iframe {
+.video-embed iframe {
   position: absolute;
   inset: 0;
   width: 100%;

--- a/src/components/YouTube.astro
+++ b/src/components/YouTube.astro
@@ -16,23 +16,3 @@ const { id, title = 'YouTube video' } = Astro.props;
 		loading="lazy"
 	></iframe>
 </div>
-
-<style>
-	.youtube-embed {
-		position: relative;
-		width: 100%;
-		aspect-ratio: 16 / 9;
-		margin: var(--sp-8) 0;
-		border-radius: var(--radius-md);
-		overflow: hidden;
-		background-color: var(--color-surface);
-	}
-	.youtube-embed iframe {
-		position: absolute;
-		inset: 0;
-		width: 100%;
-		height: 100%;
-		border: none;
-		border-radius: 0;
-	}
-</style>

--- a/src/components/YouTube.astro
+++ b/src/components/YouTube.astro
@@ -7,7 +7,7 @@ interface Props {
 const { id, title = 'YouTube video' } = Astro.props;
 ---
 
-<div class="youtube-embed">
+<div class="video-embed">
 	<iframe
 		src={`https://www.youtube-nocookie.com/embed/${id}`}
 		title={title}

--- a/src/plugins/remark-video.mjs
+++ b/src/plugins/remark-video.mjs
@@ -1,6 +1,9 @@
 import { visit } from 'unist-util-visit';
 
-const VIDEO_PATTERN = /{{< video "([^"]+)"(?:\s+"([^"]*)")? >}}/;
+// Accept straight (") and curly (“ / ”) quotes — Astro's default
+// markdown.smartypants rewrites straight quotes before this plugin runs.
+const VIDEO_PATTERN =
+	/{{< video ["“”]([^"“”]+)["“”](?:\s+["“”]([^"“”]*)["“”])? >}}/;
 
 function escapeAttr(str) {
 	return str.replace(/&/g, '&amp;').replace(/"/g, '&quot;');
@@ -18,13 +21,18 @@ function embedUrl(url) {
 	return null;
 }
 
+// Recursively collect text from a node tree. Needed because GFM autolinks
+// bare URLs into `link` nodes, splitting the shortcode across siblings.
+function collectText(node) {
+	if (node.type === 'text') return node.value;
+	if (node.children) return node.children.map(collectText).join('');
+	return '';
+}
+
 export function remarkVideo() {
 	return (tree) => {
 		visit(tree, 'paragraph', (node, index, parent) => {
-			const text = node.children
-				.filter((c) => c.type === 'text')
-				.map((c) => c.value)
-				.join('');
+			const text = node.children.map(collectText).join('');
 
 			const match = VIDEO_PATTERN.exec(text.trim());
 			if (!match) return;

--- a/src/plugins/remark-video.mjs
+++ b/src/plugins/remark-video.mjs
@@ -44,7 +44,7 @@ export function remarkVideo() {
 
 			parent.children[index] = {
 				type: 'html',
-				value: `<div class="youtube-embed"><iframe src="${src}" title="${title}" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen loading="lazy"></iframe></div>`,
+				value: `<div class="video-embed"><iframe src="${src}" title="${title}" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen loading="lazy"></iframe></div>`,
 			};
 		});
 	};

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -230,6 +230,24 @@ b {
   margin: var(--sp-8) 0;
 }
 
+.youtube-embed {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  margin: var(--sp-8) 0;
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  background-color: var(--color-surface);
+}
+.youtube-embed iframe {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  border: none;
+  border-radius: 0;
+}
+
 /* ─── Elements ────────────────────────────────────────────────────────────── */
 img {
   max-width: 100%;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -230,7 +230,7 @@ b {
   margin: var(--sp-8) 0;
 }
 
-.youtube-embed {
+.video-embed {
   position: relative;
   width: 100%;
   aspect-ratio: 16 / 9;
@@ -239,7 +239,7 @@ b {
   overflow: hidden;
   background-color: var(--color-surface);
 }
-.youtube-embed iframe {
+.video-embed iframe {
   position: absolute;
   inset: 0;
   width: 100%;


### PR DESCRIPTION
## Issue

Closes #29

## Summary

Video shortcodes rendered as raw text instead of iframes on published pages, caused by Astro's smartypants rewriting straight quotes and bare URLs being autolinked before the remark plugin matched.

## Changes

- Accept curly quotes in shortcode regex
- Walk all paragraph children to capture autolinked URLs
- Move embed styles to global CSS so they apply
- Rename class to `video-embed` (covers Vimeo too)