### PR TITLE
Add image previews to homepage recent posts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,7 +68,8 @@ This is an **Astro 6** static site (SSG) — all routes are pre-built at build t
 | `Footer.astro`        | —                                                            | Copyright year (auto), mono social links (github, vimeo, linkedin), Netlify Identity login redirect                    |
 | `TagList.astro`       | `tags: string[]`                                             | Renders clickable `#tag` pill links to `/blog/tags/[tag]/`                                                             |
 | `PostCard.astro`      | `post: CollectionEntry<'blog'>`                              | Blog post card (`<li>`) used in the grid on `/blog` and tag archive pages                                              |
-| `ProjectCard.astro`   | `project: CollectionEntry<'projects'>`, `style?: string`     | Project card (`<li>`) with image, status badge, title, description, optional featuredStat                              |
+| `PostRow.astro`       | `post: CollectionEntry<'blog'>`                              | Blog post row (`<li>`) with thumbnail, date, title, description; used in the recent posts list on the homepage         |
+| `ProjectCard.astro`   | `project: CollectionEntry<'projects'>`                       | Project card (`<li>`) with image, status badge, title, description, optional featuredStat                              |
 | `StatusBadge.astro`   | `status: 'completed' \| 'in-progress' \| 'paused'`, `class?` | Styled status badge with three visual variants                                                                         |
 | `FormattedDate.astro` | `date: Date`                                                 | Formats a `Date` as "MMM d, yyyy"                                                                                      |
 | `Hero.astro`          | —                                                            | Homepage hero: SVG logo, typewriter eyebrow, stat bar                                                                  |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,6 +73,7 @@ This is an **Astro 6** static site (SSG) — all routes are pre-built at build t
 | `StatusBadge.astro`   | `status: 'completed' \| 'in-progress' \| 'paused'`, `class?` | Styled status badge with three visual variants                                                                         |
 | `FormattedDate.astro` | `date: Date`                                                 | Formats a `Date` as "MMM d, yyyy"                                                                                      |
 | `Hero.astro`          | —                                                            | Homepage hero: SVG logo, typewriter eyebrow, stat bar                                                                  |
+| `HomeSection.astro`   | `title`, `href`, `linkLabel`, `layout: 'grid' \| 'list'`     | Wraps a homepage section (header with title + view-all link, then a `<ul>`); children passed via slot                  |
 | `YouTube.astro`       | `id: string`, `title?`                                       | Responsive 16:9 iframe embed via `youtube-nocookie.com`, lazy loaded                                                   |
 
 ## Design System

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,6 +146,10 @@ The Decap CMS video editor widget (defined in `public/admin/index.html`) produce
 
 Tags are `string[]` in post frontmatter. The `TagList` component renders them as pill links.
 
+## Commits
+
+Commit messages must be 10 words or fewer. Keep them in the imperative mood (e.g. "Add image preview to recent posts").
+
 ## Pull requests
 
 The repo has a template at `.github/pull_request_template.md` with three sections: Issue, Summary, Changes. PR descriptions should be concise and high-level — use bullet points of 5–10 words maximum.

--- a/src/components/HomeSection.astro
+++ b/src/components/HomeSection.astro
@@ -65,15 +65,4 @@ const { title, href, linkLabel, layout } = Astro.props;
 	@media (max-width: 600px) {
 		.section-grid { grid-template-columns: 1fr; gap: var(--sp-4); }
 	}
-
-	@keyframes fadeUp {
-		from { opacity: 0; transform: translateY(8px); }
-		to   { opacity: 1; transform: translateY(0); }
-	}
-
-	@media (prefers-reduced-motion: reduce) {
-		.home-section {
-			animation: none;
-		}
-	}
 </style>

--- a/src/components/HomeSection.astro
+++ b/src/components/HomeSection.astro
@@ -1,0 +1,79 @@
+---
+interface Props {
+	title: string;
+	href: string;
+	linkLabel: string;
+	layout: 'grid' | 'list';
+}
+
+const { title, href, linkLabel, layout } = Astro.props;
+---
+
+<section class="home-section">
+	<div class="section-header">
+		<h2>{title}</h2>
+		<a {href} class="view-all">{linkLabel}</a>
+	</div>
+	<ul class={layout === 'grid' ? 'section-grid' : undefined} role="list">
+		<slot />
+	</ul>
+</section>
+
+<style>
+	.home-section {
+		padding: var(--sp-6) 0;
+		animation: fadeUp 0.6s cubic-bezier(0.22, 1, 0.36, 1) both;
+		animation-delay: 0.32s;
+	}
+	.section-header {
+		display: flex;
+		align-items: baseline;
+		justify-content: space-between;
+		margin-bottom: var(--sp-8);
+	}
+	.section-header h2 {
+		margin: 0;
+	}
+	.view-all {
+		font-family: var(--font-body);
+		font-size: var(--fs-xs);
+		color: var(--color-ink-muted);
+		text-decoration: none;
+		transition: color var(--ease);
+	}
+	.view-all::after {
+		content: ' →';
+	}
+	.view-all:hover {
+		color: var(--color-ink);
+	}
+
+	ul {
+		list-style: none;
+		margin: 0;
+		padding: 0;
+	}
+
+	.section-grid {
+		display: grid;
+		grid-template-columns: repeat(3, 1fr);
+		gap: var(--sp-6);
+	}
+	@media (max-width: 900px) {
+		.section-grid { grid-template-columns: repeat(2, 1fr); }
+	}
+	@media (max-width: 600px) {
+		.section-grid { grid-template-columns: 1fr; gap: var(--sp-4); }
+	}
+
+	@keyframes fadeUp {
+		from { opacity: 0; transform: translateY(8px); }
+		to   { opacity: 1; transform: translateY(0); }
+	}
+
+	@media (prefers-reduced-motion: reduce) {
+		.home-section {
+			animation: none;
+		}
+	}
+</style>

--- a/src/components/PostCard.astro
+++ b/src/components/PostCard.astro
@@ -53,7 +53,6 @@ const { post } = Astro.props;
 		width: 100%;
 		height: 100%;
 		object-fit: cover;
-		border-radius: 0;
 		transition: transform var(--ease-slow);
 	}
 	.post-card:hover .card-image img {

--- a/src/components/PostRow.astro
+++ b/src/components/PostRow.astro
@@ -130,15 +130,4 @@ const { post } = Astro.props;
 			display: none;
 		}
 	}
-
-	@keyframes fadeUp {
-		from { opacity: 0; transform: translateY(8px); }
-		to   { opacity: 1; transform: translateY(0); }
-	}
-
-	@media (prefers-reduced-motion: reduce) {
-		.post-item {
-			animation: none;
-		}
-	}
 </style>

--- a/src/components/PostRow.astro
+++ b/src/components/PostRow.astro
@@ -1,0 +1,144 @@
+---
+import { Image } from 'astro:assets';
+import type { CollectionEntry } from 'astro:content';
+import FormattedDate from './FormattedDate.astro';
+
+interface Props {
+	post: CollectionEntry<'blog'>;
+}
+
+const { post } = Astro.props;
+---
+
+<li class="post-item">
+	<a href={`/blog/${post.id}/`} class="post-link">
+		<div class="post-thumbnail">
+			{post.data.heroImage ? (
+				<Image width={320} height={180} src={post.data.heroImage} alt="" />
+			) : (
+				<div class="post-thumbnail-placeholder" aria-hidden="true"></div>
+			)}
+		</div>
+		<div class="post-info">
+			<time class="post-date">
+				<FormattedDate date={post.data.pubDate} />
+			</time>
+			<h3 class="post-title">{post.data.title}</h3>
+			<p class="post-description">{post.data.description}</p>
+		</div>
+		<span class="post-arrow" aria-hidden="true">→</span>
+	</a>
+</li>
+
+<style>
+	.post-item {
+		border-top: 1px solid var(--color-border-subtle);
+		animation: fadeUp 0.5s cubic-bezier(0.22, 1, 0.36, 1) both;
+	}
+	.post-item:nth-child(1) { animation-delay: 0.10s; }
+	.post-item:nth-child(2) { animation-delay: 0.18s; }
+	.post-item:nth-child(3) { animation-delay: 0.26s; }
+	.post-link {
+		display: grid;
+		grid-template-columns: 200px 1fr auto;
+		align-items: center;
+		gap: var(--sp-6);
+		padding: var(--sp-5) 0;
+		text-decoration: none;
+		color: inherit;
+	}
+	.post-thumbnail {
+		aspect-ratio: 16 / 9;
+		width: 100%;
+		overflow: hidden;
+		border-radius: var(--radius-md);
+		background: var(--color-surface);
+	}
+	.post-thumbnail img {
+		width: 100%;
+		height: 100%;
+		object-fit: cover;
+		display: block;
+		transition: transform var(--ease-slow);
+	}
+	.post-thumbnail-placeholder {
+		width: 100%;
+		height: 100%;
+		background: var(--color-surface);
+	}
+	.post-link:hover .post-thumbnail img {
+		transform: scale(1.04);
+	}
+	.post-info {
+		min-width: 0;
+	}
+	.post-date {
+		display: block;
+		font-family: var(--font-mono);
+		font-size: var(--fs-xs);
+		font-weight: 500;
+		color: var(--color-ink-muted);
+		margin-bottom: var(--sp-2);
+		white-space: nowrap;
+	}
+	.post-title {
+		font-family: var(--font-body);
+		font-size: var(--fs-xl);
+		font-weight: 600;
+		margin: 0 0 var(--sp-1);
+		transition: color var(--ease);
+		line-height: 1.3;
+	}
+	.post-link:hover .post-title {
+		color: var(--color-ink-muted);
+	}
+	.post-description {
+		margin: 0;
+		font-size: var(--fs-sm);
+		color: var(--color-ink-muted);
+		line-height: 1.6;
+		display: -webkit-box;
+		-webkit-line-clamp: 2;
+		-webkit-box-orient: vertical;
+		overflow: hidden;
+	}
+	.post-arrow {
+		font-size: var(--fs-xl);
+		color: var(--color-border);
+		flex-shrink: 0;
+		transition: color var(--ease), transform var(--ease);
+	}
+	.post-link:hover .post-arrow {
+		color: var(--color-ink-muted);
+		transform: translateX(4px);
+	}
+	@media (max-width: 900px) {
+		.post-link {
+			grid-template-columns: 160px 1fr auto;
+			gap: var(--sp-5);
+		}
+	}
+	@media (max-width: 600px) {
+		.post-link {
+			grid-template-columns: 160px 1fr;
+			gap: var(--sp-4);
+		}
+		.post-arrow {
+			display: none;
+		}
+		.post-description {
+			display: none;
+		}
+	}
+
+	@keyframes fadeUp {
+		from { opacity: 0; transform: translateY(8px); }
+		to   { opacity: 1; transform: translateY(0); }
+	}
+
+	@media (prefers-reduced-motion: reduce) {
+		.post-item {
+			animation: none;
+		}
+	}
+</style>

--- a/src/components/ProjectCard.astro
+++ b/src/components/ProjectCard.astro
@@ -44,17 +44,6 @@ const status = project.data.status ?? 'in-progress';
 	.project-card:nth-child(1) { animation-delay: 0.10s; }
 	.project-card:nth-child(2) { animation-delay: 0.17s; }
 	.project-card:nth-child(3) { animation-delay: 0.24s; }
-
-	@keyframes fadeUp {
-		from { opacity: 0; transform: translateY(8px); }
-		to   { opacity: 1; transform: translateY(0); }
-	}
-
-	@media (prefers-reduced-motion: reduce) {
-		.project-card {
-			animation: none;
-		}
-	}
 	.project-card:hover {
 		box-shadow: var(--shadow-md);
 	}
@@ -66,7 +55,6 @@ const status = project.data.status ?? 'in-progress';
 		width: 100%;
 		height: 100%;
 		object-fit: cover;
-		border-radius: 0;
 		transition: transform var(--ease-slow);
 	}
 	.project-card:hover .card-image img {

--- a/src/components/ProjectCard.astro
+++ b/src/components/ProjectCard.astro
@@ -5,14 +5,13 @@ import StatusBadge from './StatusBadge.astro';
 
 interface Props {
 	project: CollectionEntry<'projects'>;
-	style?: string;
 }
 
-const { project, style } = Astro.props;
+const { project } = Astro.props;
 const status = project.data.status ?? 'in-progress';
 ---
 
-<li class="project-card" {style}>
+<li class="project-card">
 	{project.data.heroImage && (
 		<div class="card-image">
 			<Image width={560} height={315} src={project.data.heroImage} alt="" />
@@ -40,6 +39,21 @@ const status = project.data.status ?? 'in-progress';
 		border-radius: var(--radius-lg);
 		overflow: hidden;
 		transition: box-shadow var(--ease), border-color var(--ease);
+		animation: fadeUp 0.5s cubic-bezier(0.22, 1, 0.36, 1) both;
+	}
+	.project-card:nth-child(1) { animation-delay: 0.10s; }
+	.project-card:nth-child(2) { animation-delay: 0.17s; }
+	.project-card:nth-child(3) { animation-delay: 0.24s; }
+
+	@keyframes fadeUp {
+		from { opacity: 0; transform: translateY(8px); }
+		to   { opacity: 1; transform: translateY(0); }
+	}
+
+	@media (prefers-reduced-motion: reduce) {
+		.project-card {
+			animation: none;
+		}
 	}
 	.project-card:hover {
 		box-shadow: var(--shadow-md);

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,4 +1,5 @@
 ---
+import { Image } from 'astro:assets';
 import { getCollection } from 'astro:content';
 import BaseHead from '../components/BaseHead.astro';
 import Footer from '../components/Footer.astro';
@@ -69,10 +70,17 @@ const firstYear = posts[posts.length - 1]?.data.pubDate.getFullYear();
 					{recentPosts.map((post, i) => (
 						<li class="post-item" style={`animation-delay: ${0.1 + i * 0.08}s`}>
 							<a href={`/blog/${post.id}/`} class="post-link">
-								<time class="post-date">
-									<FormattedDate date={post.data.pubDate} />
-								</time>
+								<div class="post-thumbnail">
+									{post.data.heroImage ? (
+										<Image width={320} height={180} src={post.data.heroImage} alt="" />
+									) : (
+										<div class="post-thumbnail-placeholder" aria-hidden="true"></div>
+									)}
+								</div>
 								<div class="post-info">
+									<time class="post-date">
+										<FormattedDate date={post.data.pubDate} />
+									</time>
 									<h3 class="post-title">{post.data.title}</h3>
 									<p class="post-description">{post.data.description}</p>
 								</div>
@@ -150,22 +158,46 @@ const firstYear = posts[posts.length - 1]?.data.pubDate.getFullYear();
 	}
 	.post-link {
 		display: grid;
-		grid-template-columns: 112px 1fr auto;
-		align-items: baseline;
+		grid-template-columns: 200px 1fr auto;
+		align-items: center;
 		gap: var(--sp-6);
 		padding: var(--sp-5) 0 var(--sp-3);
 		text-decoration: none;
 		color: inherit;
 	}
+	.post-thumbnail {
+		aspect-ratio: 16 / 9;
+		width: 100%;
+		overflow: hidden;
+		border-radius: var(--radius-md);
+		background: var(--color-surface);
+	}
+	.post-thumbnail img {
+		width: 100%;
+		height: 100%;
+		object-fit: cover;
+		display: block;
+		transition: transform var(--ease-slow);
+	}
+	.post-thumbnail-placeholder {
+		width: 100%;
+		height: 100%;
+		background: var(--color-surface);
+	}
+	.post-link:hover .post-thumbnail img {
+		transform: scale(1.04);
+	}
+	.post-info {
+		min-width: 0;
+	}
 	.post-date {
+		display: block;
 		font-family: var(--font-mono);
 		font-size: var(--fs-xs);
 		font-weight: 500;
 		color: var(--color-ink-muted);
+		margin-bottom: var(--sp-2);
 		white-space: nowrap;
-	}
-	.post-info {
-		min-width: 0;
 	}
 	.post-title {
 		font-family: var(--font-body);
@@ -183,6 +215,10 @@ const firstYear = posts[posts.length - 1]?.data.pubDate.getFullYear();
 		font-size: var(--fs-sm);
 		color: var(--color-ink-muted);
 		line-height: 1.6;
+		display: -webkit-box;
+		-webkit-line-clamp: 2;
+		-webkit-box-orient: vertical;
+		overflow: hidden;
 	}
 	.post-arrow {
 		font-size: var(--fs-xl);
@@ -195,26 +231,28 @@ const firstYear = posts[posts.length - 1]?.data.pubDate.getFullYear();
 		transform: translateX(4px);
 	}
 	.post-tags {
-		padding-left: calc(112px + var(--sp-6));
+		padding-left: calc(200px + var(--sp-6));
 		padding-bottom: var(--sp-5);
 	}
-	@media (max-width: 768px) {
+	@media (max-width: 900px) {
 		.post-link {
-			grid-template-columns: 1fr auto;
-			grid-template-rows: auto auto;
+			grid-template-columns: 160px 1fr auto;
+			gap: var(--sp-5);
 		}
-		.post-date {
-			grid-column: 1;
-			grid-row: 1;
+		.post-tags {
+			padding-left: calc(160px + var(--sp-5));
 		}
-		.post-info {
-			grid-column: 1;
-			grid-row: 2;
+	}
+	@media (max-width: 600px) {
+		.post-link {
+			grid-template-columns: 160px 1fr;
+			gap: var(--sp-4);
 		}
 		.post-arrow {
-			grid-column: 2;
-			grid-row: 1 / 3;
-			align-self: center;
+			display: none;
+		}
+		.post-description {
+			display: none;
 		}
 		.post-tags {
 			padding-left: 0;

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,11 +1,10 @@
 ---
-import { Image } from 'astro:assets';
 import { getCollection } from 'astro:content';
 import BaseHead from '../components/BaseHead.astro';
 import Footer from '../components/Footer.astro';
-import FormattedDate from '../components/FormattedDate.astro';
 import Header from '../components/Header.astro';
 import Hero from '../components/Hero.astro';
+import PostRow from '../components/PostRow.astro';
 import ProjectCard from '../components/ProjectCard.astro';
 import { SITE_DESCRIPTION, SITE_TITLE } from '../consts';
 
@@ -30,9 +29,6 @@ const posts = allPosts.sort(
 );
 const recentPosts = posts.slice(0, 3);
 
-const allTags = [...new Set(posts.flatMap((p) => p.data.tags ?? []))];
-const postCount = posts.length;
-const firstYear = posts[posts.length - 1]?.data.pubDate.getFullYear();
 ---
 
 <!doctype html>
@@ -51,11 +47,8 @@ const firstYear = posts[posts.length - 1]?.data.pubDate.getFullYear();
 					<a href="/projects" class="view-all">All projects →</a>
 				</div>
 				<ul class="projects-grid" role="list">
-					{featuredProjects.map((project, i) => (
-						<ProjectCard
-							project={project}
-							style={`animation-delay:${0.1 + i * 0.07}s`}
-						/>
+					{featuredProjects.map((project) => (
+						<ProjectCard project={project} />
 					))}
 				</ul>
 			</section>
@@ -66,26 +59,8 @@ const firstYear = posts[posts.length - 1]?.data.pubDate.getFullYear();
 					<a href="/blog" class="view-all">All posts →</a>
 				</div>
 				<ul class="post-list" role="list">
-					{recentPosts.map((post, i) => (
-						<li class="post-item" style={`animation-delay: ${0.1 + i * 0.08}s`}>
-							<a href={`/blog/${post.id}/`} class="post-link">
-								<div class="post-thumbnail">
-									{post.data.heroImage ? (
-										<Image width={320} height={180} src={post.data.heroImage} alt="" />
-									) : (
-										<div class="post-thumbnail-placeholder" aria-hidden="true"></div>
-									)}
-								</div>
-								<div class="post-info">
-									<time class="post-date">
-										<FormattedDate date={post.data.pubDate} />
-									</time>
-									<h3 class="post-title">{post.data.title}</h3>
-									<p class="post-description">{post.data.description}</p>
-								</div>
-								<span class="post-arrow" aria-hidden="true">→</span>
-							</a>
-						</li>
+					{recentPosts.map((post) => (
+						<PostRow post={post} />
 					))}
 				</ul>
 			</section>
@@ -146,102 +121,6 @@ const firstYear = posts[posts.length - 1]?.data.pubDate.getFullYear();
 		margin: 0;
 		padding: 0;
 	}
-	.post-item {
-		border-top: 1px solid var(--color-border-subtle);
-		animation: fadeUp 0.5s cubic-bezier(0.22, 1, 0.36, 1) both;
-	}
-	.post-link {
-		display: grid;
-		grid-template-columns: 200px 1fr auto;
-		align-items: center;
-		gap: var(--sp-6);
-		padding: var(--sp-5) 0;
-		text-decoration: none;
-		color: inherit;
-	}
-	.post-thumbnail {
-		aspect-ratio: 16 / 9;
-		width: 100%;
-		overflow: hidden;
-		border-radius: var(--radius-md);
-		background: var(--color-surface);
-	}
-	.post-thumbnail img {
-		width: 100%;
-		height: 100%;
-		object-fit: cover;
-		display: block;
-		transition: transform var(--ease-slow);
-	}
-	.post-thumbnail-placeholder {
-		width: 100%;
-		height: 100%;
-		background: var(--color-surface);
-	}
-	.post-link:hover .post-thumbnail img {
-		transform: scale(1.04);
-	}
-	.post-info {
-		min-width: 0;
-	}
-	.post-date {
-		display: block;
-		font-family: var(--font-mono);
-		font-size: var(--fs-xs);
-		font-weight: 500;
-		color: var(--color-ink-muted);
-		margin-bottom: var(--sp-2);
-		white-space: nowrap;
-	}
-	.post-title {
-		font-family: var(--font-body);
-		font-size: var(--fs-xl);
-		font-weight: 600;
-		margin: 0 0 var(--sp-1);
-		transition: color var(--ease);
-		line-height: 1.3;
-	}
-	.post-link:hover .post-title {
-		color: var(--color-ink-muted);
-	}
-	.post-description {
-		margin: 0;
-		font-size: var(--fs-sm);
-		color: var(--color-ink-muted);
-		line-height: 1.6;
-		display: -webkit-box;
-		-webkit-line-clamp: 2;
-		-webkit-box-orient: vertical;
-		overflow: hidden;
-	}
-	.post-arrow {
-		font-size: var(--fs-xl);
-		color: var(--color-border);
-		flex-shrink: 0;
-		transition: color var(--ease), transform var(--ease);
-	}
-	.post-link:hover .post-arrow {
-		color: var(--color-ink-muted);
-		transform: translateX(4px);
-	}
-	@media (max-width: 900px) {
-		.post-link {
-			grid-template-columns: 160px 1fr auto;
-			gap: var(--sp-5);
-		}
-	}
-	@media (max-width: 600px) {
-		.post-link {
-			grid-template-columns: 160px 1fr;
-			gap: var(--sp-4);
-		}
-		.post-arrow {
-			display: none;
-		}
-		.post-description {
-			display: none;
-		}
-	}
 
 	@keyframes fadeUp {
 		from { opacity: 0; transform: translateY(8px); }
@@ -249,7 +128,7 @@ const firstYear = posts[posts.length - 1]?.data.pubDate.getFullYear();
 	}
 
 	@media (prefers-reduced-motion: reduce) {
-		.featured-projects, .recent-posts, .post-item {
+		.featured-projects, .recent-posts {
 			animation: none;
 		}
 	}

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -4,6 +4,7 @@ import BaseHead from '../components/BaseHead.astro';
 import Footer from '../components/Footer.astro';
 import Header from '../components/Header.astro';
 import Hero from '../components/Hero.astro';
+import HomeSection from '../components/HomeSection.astro';
 import PostRow from '../components/PostRow.astro';
 import ProjectCard from '../components/ProjectCard.astro';
 import { SITE_DESCRIPTION, SITE_TITLE } from '../consts';
@@ -41,95 +42,28 @@ const recentPosts = posts.slice(0, 3);
 		<main>
 			<Hero />
 
-			<section class="featured-projects">
-				<div class="section-header">
-					<h2>Featured Projects</h2>
-					<a href="/projects" class="view-all">All projects →</a>
-				</div>
-				<ul class="projects-grid" role="list">
-					{featuredProjects.map((project) => (
-						<ProjectCard project={project} />
-					))}
-				</ul>
-			</section>
+			<HomeSection
+				title="Featured Projects"
+				href="/projects"
+				linkLabel="All projects"
+				layout="grid"
+			>
+				{featuredProjects.map((project) => (
+					<ProjectCard project={project} />
+				))}
+			</HomeSection>
 
-			<section class="recent-posts">
-				<div class="section-header">
-					<h2>Recent Posts</h2>
-					<a href="/blog" class="view-all">All posts →</a>
-				</div>
-				<ul class="post-list" role="list">
-					{recentPosts.map((post) => (
-						<PostRow post={post} />
-					))}
-				</ul>
-			</section>
+			<HomeSection
+				title="Recent Posts"
+				href="/blog"
+				linkLabel="All posts"
+				layout="list"
+			>
+				{recentPosts.map((post) => (
+					<PostRow post={post} />
+				))}
+			</HomeSection>
 		</main>
 		<Footer />
 	</body>
 </html>
-
-<style>
-	/* ── Featured Projects ── */
-	.featured-projects {
-		padding: var(--sp-4) 0;
-		animation: fadeUp 0.6s cubic-bezier(0.22, 1, 0.36, 1) both;
-		animation-delay: 0.32s;
-	}
-	.projects-grid {
-		list-style: none;
-		margin: 0;
-		padding: 0;
-		display: grid;
-		grid-template-columns: repeat(3, 1fr);
-		gap: var(--sp-6);
-	}
-	@media (max-width: 900px) {
-		.projects-grid { grid-template-columns: repeat(2, 1fr); }
-	}
-	@media (max-width: 600px) {
-		.projects-grid { grid-template-columns: 1fr; gap: var(--sp-4); }
-	}
-
-	/* ── Recent Posts ── */
-	.recent-posts {
-		padding: var(--sp-8) 0 var(--sp-4);
-		animation: fadeUp 0.6s cubic-bezier(0.22, 1, 0.36, 1) both;
-		animation-delay: 0.35s;
-	}
-	.section-header {
-		display: flex;
-		align-items: baseline;
-		justify-content: space-between;
-		margin-bottom: var(--sp-8);
-	}
-	.section-header h2 {
-		margin: 0;
-	}
-	.view-all {
-		font-family: var(--font-body);
-		font-size: var(--fs-xs);
-		color: var(--color-ink-muted);
-		text-decoration: none;
-		transition: color var(--ease);
-	}
-	.view-all:hover {
-		color: var(--color-ink);
-	}
-	.post-list {
-		list-style: none;
-		margin: 0;
-		padding: 0;
-	}
-
-	@keyframes fadeUp {
-		from { opacity: 0; transform: translateY(8px); }
-		to   { opacity: 1; transform: translateY(0); }
-	}
-
-	@media (prefers-reduced-motion: reduce) {
-		.featured-projects, .recent-posts {
-			animation: none;
-		}
-	}
-</style>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -7,7 +7,6 @@ import FormattedDate from '../components/FormattedDate.astro';
 import Header from '../components/Header.astro';
 import Hero from '../components/Hero.astro';
 import ProjectCard from '../components/ProjectCard.astro';
-import TagList from '../components/TagList.astro';
 import { SITE_DESCRIPTION, SITE_TITLE } from '../consts';
 
 // ── Featured projects ── edit this array to change which projects are shown
@@ -86,11 +85,6 @@ const firstYear = posts[posts.length - 1]?.data.pubDate.getFullYear();
 								</div>
 								<span class="post-arrow" aria-hidden="true">→</span>
 							</a>
-							{post.data.tags && post.data.tags.length > 0 && (
-								<div class="post-tags">
-									<TagList tags={post.data.tags} />
-								</div>
-							)}
 						</li>
 					))}
 				</ul>
@@ -230,17 +224,10 @@ const firstYear = posts[posts.length - 1]?.data.pubDate.getFullYear();
 		color: var(--color-ink-muted);
 		transform: translateX(4px);
 	}
-	.post-tags {
-		padding-left: calc(200px + var(--sp-6));
-		padding-bottom: var(--sp-5);
-	}
 	@media (max-width: 900px) {
 		.post-link {
 			grid-template-columns: 160px 1fr auto;
 			gap: var(--sp-5);
-		}
-		.post-tags {
-			padding-left: calc(160px + var(--sp-5));
 		}
 	}
 	@media (max-width: 600px) {
@@ -253,9 +240,6 @@ const firstYear = posts[posts.length - 1]?.data.pubDate.getFullYear();
 		}
 		.post-description {
 			display: none;
-		}
-		.post-tags {
-			padding-left: 0;
 		}
 	}
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -161,7 +161,7 @@ const firstYear = posts[posts.length - 1]?.data.pubDate.getFullYear();
 		grid-template-columns: 200px 1fr auto;
 		align-items: center;
 		gap: var(--sp-6);
-		padding: var(--sp-5) 0 var(--sp-3);
+		padding: var(--sp-5) 0;
 		text-decoration: none;
 		color: inherit;
 	}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -353,3 +353,17 @@ html.theme-transitioning *::after {
   clip-path: inset(50%);
   white-space: nowrap;
 }
+
+/* ─── Animation primitives ────────────────────────────────────────────────── */
+@keyframes fadeUp {
+  from { opacity: 0; transform: translateY(8px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}


### PR DESCRIPTION
## Issue

Closes #17

## Summary

Adds image previews to the recent posts component on the homepage and extracts the row, section, and animation primitives into reusable building blocks.

## Changes

- Add image preview to recent posts on homepage
- Remove tags from homepage recent posts
- Extract PostRow component for blog post rows
- Extract HomeSection component wrapping homepage sections
- Move stagger animations into row and card components
- Hoist fadeUp keyframe and reduced-motion to global.css
- Drop redundant border-radius reset from card images
- Document 10-word commit message rule in CLAUDE.md