### PR TITLE
Add basic SEO

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -11,5 +11,10 @@ export default defineConfig({
 	markdown: {
 		remarkPlugins: [remarkVideo],
 	},
-	integrations: [mdx(), sitemap()],
+	integrations: [
+		mdx(),
+		sitemap({
+			filter: (page) => !page.includes('/admin/'),
+		}),
+	],
 });

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,5 @@
+User-agent: *
+Allow: /
+Disallow: /admin/
+
+Sitemap: https://makeventures.netlify.app/sitemap-index.xml

--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -10,11 +10,12 @@ interface Props {
 	title: string;
 	description: string;
 	image?: ImageMetadata;
+	ogType?: 'website' | 'article';
 }
 
 const canonicalURL = new URL(Astro.url.pathname, Astro.site);
 
-const { title, description, image = FallbackImage } = Astro.props;
+const { title, description, image = FallbackImage, ogType = 'website' } = Astro.props;
 ---
 
 <!-- Theme: applied before first paint to avoid flash of wrong theme -->
@@ -57,7 +58,7 @@ const { title, description, image = FallbackImage } = Astro.props;
 <meta name="description" content={description} />
 
 <!-- Open Graph / Facebook -->
-<meta property="og:type" content="website" />
+<meta property="og:type" content={ogType} />
 <meta property="og:url" content={Astro.url} />
 <meta property="og:title" content={title} />
 <meta property="og:description" content={description} />

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -15,7 +15,7 @@ const { title, description, pubDate, updatedDate, heroImage, tags, author } = As
 <html lang="en">
 	<head>
 		<BaseHead title={title} description={description} ogType="article" />
-		<script type="application/ld+json" set:html={JSON.stringify({
+		<script is:inline type="application/ld+json" set:html={JSON.stringify({
 			'@context': 'https://schema.org',
 			'@type': 'Article',
 			headline: title,

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -14,7 +14,18 @@ const { title, description, pubDate, updatedDate, heroImage, tags, author } = As
 
 <html lang="en">
 	<head>
-		<BaseHead title={title} description={description} />
+		<BaseHead title={title} description={description} ogType="article" />
+		<script type="application/ld+json" set:html={JSON.stringify({
+			'@context': 'https://schema.org',
+			'@type': 'Article',
+			headline: title,
+			description,
+			datePublished: pubDate.toISOString(),
+			...(updatedDate ? { dateModified: updatedDate.toISOString() } : {}),
+			...(author ? { author: { '@type': 'Person', name: author } } : {}),
+			...(heroImage ? { image: new URL(heroImage.src, Astro.site).toString() } : {}),
+			url: new URL(Astro.url.pathname, Astro.site).toString(),
+		})} />
 	</head>
 
 	<body>


### PR DESCRIPTION
## Issue

Closes #38

## Summary

Add foundational SEO improvements to the site.

## Changes

- Add `robots.txt` allowing all crawlers, blocking `/admin/`
- Exclude `/admin/` from sitemap via filter in `astro.config.mjs`
- Add `ogType` prop to `BaseHead`; blog posts now emit `og:type: article`
- Add JSON-LD `Article` schema to `BlogPost.astro` for rich search results