### PR TITLE
Order projects by publish date

### DIFF
--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -54,13 +54,14 @@ collections:
     folder: 'src/content/projects'
     create: true
     slug: '{{slug}}'
-    summary: '{{status}} — {{title}}'
-    sortable_fields: ['title', 'status']
+    summary: '{{pubDate | date("YYYY-MM-DD")}} — {{title}}'
+    sortable_fields: ['pubDate', 'title', 'status']
     media_folder: '../../assets'
     public_folder: '../../assets'
     fields:
       - { label: 'Title', name: 'title', widget: 'string' }
       - { label: 'Description', name: 'description', widget: 'text' }
+      - { label: 'Publish Date', name: 'pubDate', widget: 'datetime' }
       - {
           label: 'Status',
           name: 'status',

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -27,6 +27,7 @@ const projects = defineCollection({
 			navTitle: z.string().optional(),
 			description: z.string(),
 			heroImage: z.optional(image()),
+			pubDate: z.coerce.date(),
 			status: z.enum(['completed', 'in-progress', 'paused']).optional(),
 			completedDate: z.coerce.date().optional(),
 			featuredStat: z.string().optional(),

--- a/src/content/projects/at-home-with-esphome.mdx
+++ b/src/content/projects/at-home-with-esphome.mdx
@@ -3,6 +3,7 @@ title: 'At Home with ESPHome'
 navTitle: 'ESPHome'
 description: 'Building custom smart home sensors with ESP8266 and ESP32 microcontrollers — temperature, humidity, motion, and more, all integrated seamlessly into Home Assistant.'
 heroImage: '../../assets/blog-placeholder-3.jpg'
+pubDate: 2026-03-27
 status: 'in-progress'
 featuredStat: '12 devices'
 ---

--- a/src/content/projects/beside-lights.mdx
+++ b/src/content/projects/beside-lights.mdx
@@ -1,4 +1,5 @@
 ---
+pubDate: 2026-03-27
 title: 'Project: Beside Lights'
 navTitle: 'Beside Lights'
 description: 'Designing and building custom PCB bedside lamps with warm ambient lighting, capacitive touch dimming, and Home Assistant integration — no off-the-shelf parts allowed.'

--- a/src/content/projects/coolest-things-automated.mdx
+++ b/src/content/projects/coolest-things-automated.mdx
@@ -1,4 +1,5 @@
 ---
+pubDate: 2026-03-27
 title: "Coolest Things I've Automated"
 navTitle: 'Automations'
 description: "A curated collection of the home automations I'm most proud of — the ones that actually changed how I interact with my space, not just the ones that technically worked."

--- a/src/content/projects/cottage-stuff.mdx
+++ b/src/content/projects/cottage-stuff.mdx
@@ -1,4 +1,5 @@
 ---
+pubDate: 2026-03-27
 title: 'Project: Cottage Stuff'
 navTitle: 'Cottage'
 description: 'Bringing smart home tech to a remote cottage — solar-powered sensors, cellular connectivity, water level monitoring, and knowing if a pipe froze before driving four hours to find out.'

--- a/src/content/projects/final-cut-pro-amnesia.mdx
+++ b/src/content/projects/final-cut-pro-amnesia.mdx
@@ -1,4 +1,5 @@
 ---
+pubDate: 2026-03-27
 title: 'Final Cut Pro, Amnesia'
 navTitle: 'Final Cut'
 description: 'Rediscovering video editing after years away — relearning Final Cut Pro, building a color grading workflow, and trying to figure out what my visual style actually is.'

--- a/src/content/projects/find-my-shit.mdx
+++ b/src/content/projects/find-my-shit.mdx
@@ -1,4 +1,5 @@
 ---
+pubDate: 2026-03-27
 title: 'Project: Find My Shit'
 navTitle: 'Find My Shit'
 description: 'Building a self-hosted asset tracking system using Bluetooth tags, ESPHome scanners, and Home Assistant — because losing your keys should be a solvable problem.'

--- a/src/content/projects/home-assistance-journey.mdx
+++ b/src/content/projects/home-assistance-journey.mdx
@@ -1,4 +1,5 @@
 ---
+pubDate: 2026-03-27
 title: 'The Home Assistance Journey'
 navTitle: 'Home Assist'
 description: 'How a Raspberry Pi in a drawer became the backbone of a fully automated apartment — dashboards, voice control, and automations that actually work.'

--- a/src/content/projects/lab-desk.mdx
+++ b/src/content/projects/lab-desk.mdx
@@ -1,4 +1,5 @@
 ---
+pubDate: 2026-03-27
 title: 'Project: Lab Desk'
 navTitle: 'Lab Desk'
 description: 'Designing and building a dedicated maker workspace — a custom desk with integrated power distribution, LED task lighting, tool organization, and a proper soldering station.'

--- a/src/content/projects/outdoor-stair-decay.mdx
+++ b/src/content/projects/outdoor-stair-decay.mdx
@@ -1,4 +1,5 @@
 ---
+pubDate: 2026-03-27
 title: 'From Tile to Pain: My Outdoor Stair Decay Answer'
 navTitle: 'Stair Lights'
 description: 'Replacing deteriorating outdoor tile stairs with integrated LED stair lighting — a construction project that became a smart lighting project that became an electrical project.'

--- a/src/content/projects/rabbit-hole-of-self-hosting.mdx
+++ b/src/content/projects/rabbit-hole-of-self-hosting.mdx
@@ -1,4 +1,5 @@
 ---
+pubDate: 2026-03-27
 title: 'The Rabbit Hole of Self Hosting'
 navTitle: 'Self Hosting'
 description: 'A journey into running your own services — from a single Raspberry Pi to a proper homelab with Proxmox, VMs, containers, and a healthy obsession with uptime.'

--- a/src/content/projects/six-monitors-a-necessary-and-completely-reasonable-life-decision.md
+++ b/src/content/projects/six-monitors-a-necessary-and-completely-reasonable-life-decision.md
@@ -3,6 +3,7 @@ title: "Six Monitors: A Necessary and Completely Reasonable Life Decision"
 description: "I want to be upfront about something: I work from home, I am one
   person, and I have six monitors. I'm not going to apologize for this. What I
   *am* going to do is explain it, because the explanation is airtight"
+pubDate: 2026-04-06
 status: in-progress
 completedDate: 2026-04-06T09:00:00.000Z
 heroImage: ../../assets/monitors.jpg

--- a/src/content/projects/the-blockchain-verified-doorbell.md
+++ b/src/content/projects/the-blockchain-verified-doorbell.md
@@ -1,6 +1,7 @@
 ---
 title: The Blockchain-Verified Doorbell
 description: "Why ring a doorbell like it's 1995? "
+pubDate: 2026-04-26
 status: in-progress
 heroImage: ../../assets/doorbell.jpg
 ---

--- a/src/content/projects/the-little-library-project.md
+++ b/src/content/projects/the-little-library-project.md
@@ -2,6 +2,7 @@
 title: The Little Library Project
 description: Modernize and expand on data collection of a front-lawn Library
   Exchange with ESPHOME and Home Assistant
+pubDate: 2026-04-07
 status: in-progress
 heroImage: ../../assets/screenshot-2026-04-06-at-10.09.18 pm.png
 ---

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -23,7 +23,7 @@ const [allProjects, allPosts] = await Promise.all([
 
 const featuredProjects = FEATURED_PROJECT_IDS
 	.map(id => allProjects.find(p => p.id === id))
-	.filter(p => p !== undefined);
+	.filter((p): p is NonNullable<typeof p> => p !== undefined);
 
 const posts = allPosts.sort(
 	(a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf(),

--- a/src/pages/projects/index.astro
+++ b/src/pages/projects/index.astro
@@ -8,15 +8,12 @@ import ProjectCard from '../../components/ProjectCard.astro';
 import StatusBadge from '../../components/StatusBadge.astro';
 import { SITE_DESCRIPTION, SITE_TITLE } from '../../consts';
 
-const statusOrder = { completed: 0, 'in-progress': 1, paused: 2 } as const;
-
-const projects = (await getCollection('projects')).sort((a, b) => {
-	const aOrder = statusOrder[a.data.status ?? 'in-progress'];
-	const bOrder = statusOrder[b.data.status ?? 'in-progress'];
-	return aOrder - bOrder;
-});
+const projects = (await getCollection('projects')).sort(
+	(a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf()
+);
 
 const [featured, ...rest] = projects;
+if (!featured) throw new Error('No projects found');
 
 const completedCount  = projects.filter(p => p.data.status === 'completed').length;
 const inProgressCount = projects.filter(p => (p.data.status ?? 'in-progress') === 'in-progress').length;

--- a/src/pages/projects/index.astro
+++ b/src/pages/projects/index.astro
@@ -1,6 +1,7 @@
 ---
 import { Image } from 'astro:assets';
 import { getCollection } from 'astro:content';
+import type { CollectionEntry } from 'astro:content';
 import BaseHead from '../../components/BaseHead.astro';
 import Footer from '../../components/Footer.astro';
 import Header from '../../components/Header.astro';
@@ -8,16 +9,18 @@ import ProjectCard from '../../components/ProjectCard.astro';
 import StatusBadge from '../../components/StatusBadge.astro';
 import { SITE_DESCRIPTION, SITE_TITLE } from '../../consts';
 
+type Project = CollectionEntry<'projects'>;
+
 const projects = (await getCollection('projects')).sort(
-	(a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf()
+	(a: Project, b: Project) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf()
 );
 
 const [featured, ...rest] = projects;
 if (!featured) throw new Error('No projects found');
 
-const completedCount  = projects.filter(p => p.data.status === 'completed').length;
-const inProgressCount = projects.filter(p => (p.data.status ?? 'in-progress') === 'in-progress').length;
-const pausedCount     = projects.filter(p => p.data.status === 'paused').length;
+const completedCount  = projects.filter((p: Project) => p.data.status === 'completed').length;
+const inProgressCount = projects.filter((p: Project) => (p.data.status ?? 'in-progress') === 'in-progress').length;
+const pausedCount     = projects.filter((p: Project) => p.data.status === 'paused').length;
 ---
 
 <!doctype html>
@@ -75,7 +78,7 @@ const pausedCount     = projects.filter(p => p.data.status === 'paused').length;
 			</div>
 
 			<ul class="project-grid" role="list">
-				{rest.map((project) => (
+				{rest.map((project: Project) => (
 					<ProjectCard project={project} />
 				))}
 			</ul>

--- a/src/pages/projects/index.astro
+++ b/src/pages/projects/index.astro
@@ -78,11 +78,8 @@ const pausedCount     = projects.filter(p => p.data.status === 'paused').length;
 			</div>
 
 			<ul class="project-grid" role="list">
-				{rest.map((project, i) => (
-					<ProjectCard
-						project={project}
-						style={`animation-delay:${Math.min(0.1 + i * 0.05, 0.35)}s`}
-					/>
+				{rest.map((project) => (
+					<ProjectCard project={project} />
 				))}
 			</ul>
 		</main>


### PR DESCRIPTION
## Issue

Closes #

## Summary

Adds a mandatory `pubDate` field to the projects collection and sorts projects newest-first by that date.

## Changes

- Add `pubDate` to projects Zod schema (required)
- Backfill `pubDate` on all 13 project files using git commit dates
- Replace status-based sort with `pubDate` descending sort
- Update Decap CMS config to expose `pubDate` field for projects
- Fix implicit-any type errors in `projects/index.astro`
- Fix type error from `style` prop passed to `ProjectCard`