### PR TITLE
Make heroImage, tags, and author mandatory

### DIFF
--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -29,14 +29,14 @@ collections:
           label: 'Hero Image',
           name: 'heroImage',
           widget: 'image',
-          required: false,
+          required: true,
           hint: 'Landscape JPG, at least 1920×900, max 800 KB. Compress with Squoosh (https://squoosh.app) before uploading.',
         }
       - {
           label: 'Tags',
           name: 'tags',
           widget: 'list',
-          required: false,
+          required: true,
           field: { label: 'Tag', name: 'tag', widget: 'string' },
           hint: 'Add tags one at a time',
         }
@@ -44,7 +44,7 @@ collections:
           label: 'Author',
           name: 'author',
           widget: 'string',
-          required: false,
+          required: true,
           default: 'Igor Samuk',
         }
       - { label: 'Body', name: 'body', widget: 'markdown' }
@@ -80,7 +80,7 @@ collections:
           label: 'Hero Image',
           name: 'heroImage',
           widget: 'image',
-          required: false,
+          required: true,
           hint: 'Landscape JPG, at least 1920×900, max 800 KB. Compress with Squoosh (https://squoosh.app) before uploading.',
         }
       - { label: 'Body', name: 'body', widget: 'markdown' }

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -13,9 +13,9 @@ const blog = defineCollection({
 			// Transform string to Date object
 			pubDate: z.coerce.date(),
 			updatedDate: z.coerce.date().optional(),
-			heroImage: z.optional(image()),
-			tags: z.array(z.string()).optional(),
-			author: z.string().optional(),
+			heroImage: image(),
+			tags: z.array(z.string()),
+			author: z.string(),
 		}),
 });
 
@@ -26,7 +26,7 @@ const projects = defineCollection({
 			title: z.string(),
 			navTitle: z.string().optional(),
 			description: z.string(),
-			heroImage: z.optional(image()),
+			heroImage: image(),
 			pubDate: z.coerce.date(),
 			status: z.enum(['completed', 'in-progress', 'paused']).optional(),
 			completedDate: z.coerce.date().optional(),

--- a/src/content/blog/ai-yai-yai.md
+++ b/src/content/blog/ai-yai-yai.md
@@ -5,6 +5,7 @@ description: >
   Picard would not have been nearly as effective or successful in battle. 
 pubDate: 2026-04-12T19:44:00.000Z
 heroImage: ../../assets/data.jpeg
+tags: ['AI']
 author: Igor Samuk
 ---
 From the moment I first installed and typed "Claude" at my raspiOS command prompt, I have been blown away by what is possible with this tool.  The Star Trek character Captain Jean Luke Picard had an A.I. android; Commander Data, next to him providing him with the sum total of the universe's knowledge and hands on capability at his finger tips whenever it was needed.  That is how I feel when I wake up my instance of Claude and begin solving, building, learning and above all else saving a tonne of time to get things done.

--- a/src/content/blog/test-this-new-blog.md
+++ b/src/content/blog/test-this-new-blog.md
@@ -3,6 +3,7 @@ title: Test this new Blog
 description: This is just a test. If this was a real test it would be real.
 pubDate: 2026-04-06T21:57:00.000Z
 heroImage: ../../assets/a-study-in-bubbles.jpg
+tags: ['test']
 author: Igor Samuk
 ---
 Yes it was discovered that Bubbles can lead to PhDs.

--- a/src/content/blog/test.md
+++ b/src/content/blog/test.md
@@ -3,6 +3,7 @@ title: Feels good man
 description: Test
 pubDate: 2026-04-25T16:30:00.000Z
 heroImage: ../../assets/pexels-coding-1853305_1920.jpg
+tags: ['test']
 author: Igor Samuk
 ---
 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.


### PR DESCRIPTION
## Issue

N/A

## Summary

Enforce required fields for blog posts and project pages in both the CMS admin panel and Zod content schemas.

## Changes

- Make heroImage required on blog posts and projects
- Make tags and author required on blog posts
- Add missing tags to 3 existing blog posts