### PR TITLE
Remove image restrictions

### DIFF
--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -30,7 +30,7 @@ collections:
           name: 'heroImage',
           widget: 'image',
           required: true,
-          hint: 'Landscape JPG, at least 1920×900, max 800 KB. Compress with Squoosh (https://squoosh.app) before uploading.',
+          hint: 'Max 800 KB. Compress with Squoosh (https://squoosh.app) before uploading.',
         }
       - {
           label: 'Tags',
@@ -81,6 +81,6 @@ collections:
           name: 'heroImage',
           widget: 'image',
           required: true,
-          hint: 'Landscape JPG, at least 1920×900, max 800 KB. Compress with Squoosh (https://squoosh.app) before uploading.',
+          hint: 'Max 800 KB. Compress with Squoosh (https://squoosh.app) before uploading.',
         }
       - { label: 'Body', name: 'body', widget: 'markdown' }

--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -30,7 +30,7 @@ collections:
           name: 'heroImage',
           widget: 'image',
           required: true,
-          hint: 'Max 800 KB. Compress with Squoosh (https://squoosh.app) before uploading.',
+          hint: 'JPG, max 800 KB. Compress with Squoosh (https://squoosh.app) before uploading.',
         }
       - {
           label: 'Tags',
@@ -81,6 +81,6 @@ collections:
           name: 'heroImage',
           widget: 'image',
           required: true,
-          hint: 'Max 800 KB. Compress with Squoosh (https://squoosh.app) before uploading.',
+          hint: 'JPG, max 800 KB. Compress with Squoosh (https://squoosh.app) before uploading.',
         }
       - { label: 'Body', name: 'body', widget: 'markdown' }

--- a/public/admin/scripts/constants.js
+++ b/public/admin/scripts/constants.js
@@ -1,9 +1,10 @@
-// Validation threshold for hero image uploads. Sourced by hero-validation.js
-// for both the check and the matching user-facing error message, so the
-// value can't drift between the rule and the message.
+// Validation thresholds for hero image uploads. Sourced by hero-validation.js
+// for both the checks and the matching user-facing error messages, so values
+// can't drift between the rule and the message.
 
 window.AdminHelpers = window.AdminHelpers || {};
 
 window.AdminHelpers.HERO_LIMITS = {
   maxBytes: 800 * 1024,
+  allowedExtensions: ['.jpg', '.jpeg'],
 };

--- a/public/admin/scripts/constants.js
+++ b/public/admin/scripts/constants.js
@@ -1,13 +1,9 @@
-// Validation thresholds for hero image uploads. Sourced by hero-validation.js
-// for both the checks and the matching user-facing error messages, so values
-// can't drift between the rule and the message.
+// Validation threshold for hero image uploads. Sourced by hero-validation.js
+// for both the check and the matching user-facing error message, so the
+// value can't drift between the rule and the message.
 
 window.AdminHelpers = window.AdminHelpers || {};
 
 window.AdminHelpers.HERO_LIMITS = {
-  minWidth: 1920,
-  minHeight: 900,
-  minAspectRatio: 1.5,
   maxBytes: 800 * 1024,
-  allowedExtensions: ['.jpg', '.jpeg'],
 };

--- a/public/admin/scripts/hero-validation.js
+++ b/public/admin/scripts/hero-validation.js
@@ -1,7 +1,8 @@
 // preSave event listener that blocks Save when a pending heroImage upload
-// exceeds our file-size limit. Only validates uploads that haven't been
-// committed yet — already-saved hero images are skipped. The threshold and
-// matching error-message value come from HERO_LIMITS in constants.js.
+// fails our constraints (format, file size). Only validates uploads that
+// haven't been committed yet — already-saved hero images are skipped. All
+// thresholds and matching error-message values come from HERO_LIMITS in
+// constants.js.
 
 (() => {
   const { HERO_LIMITS, formatBytes } = window.AdminHelpers;
@@ -18,7 +19,9 @@
     const pending = mediaFiles.find(
       (f) => (f.get('path') || '').split('/').pop() === heroName,
     );
-    return pending ? pending.get('url') : null;
+    if (!pending || !pending.get('url')) return null;
+
+    return { path: heroPath, url: pending.get('url') };
   }
 
   function loadImageBlob(url) {
@@ -32,15 +35,27 @@
   CMS.registerEventListener({
     name: 'preSave',
     handler: async (event) => {
-      const url = resolveHeroImageUrl(event.entry);
-      if (!url) return;
+      const resolved = resolveHeroImageUrl(event.entry);
+      if (!resolved) return;
 
-      const blob = await loadImageBlob(url);
+      const blob = await loadImageBlob(resolved.url);
 
+      const errors = [];
+      const path = resolved.path.toLowerCase();
+      const hasAllowedExt = HERO_LIMITS.allowedExtensions.some((ext) =>
+        path.endsWith(ext),
+      );
+      if (!hasAllowedExt) {
+        errors.push('Hero image must be a JPG/JPEG.');
+      }
       if (blob.size > HERO_LIMITS.maxBytes) {
-        throw new Error(
+        errors.push(
           `Hero image is ${formatBytes(blob.size)}. Maximum is ${formatBytes(HERO_LIMITS.maxBytes)}. Please compress and re-upload.`,
         );
+      }
+
+      if (errors.length) {
+        throw new Error(errors.join('\n'));
       }
     },
   });

--- a/public/admin/scripts/hero-validation.js
+++ b/public/admin/scripts/hero-validation.js
@@ -1,8 +1,7 @@
 // preSave event listener that blocks Save when a pending heroImage upload
-// fails our constraints (format, dimensions, aspect ratio, file size). Only
-// validates uploads that haven't been committed yet — already-saved hero
-// images are skipped. All thresholds and matching error-message values come
-// from HERO_LIMITS in constants.js.
+// exceeds our file-size limit. Only validates uploads that haven't been
+// committed yet — already-saved hero images are skipped. The threshold and
+// matching error-message value come from HERO_LIMITS in constants.js.
 
 (() => {
   const { HERO_LIMITS, formatBytes } = window.AdminHelpers;
@@ -19,20 +18,7 @@
     const pending = mediaFiles.find(
       (f) => (f.get('path') || '').split('/').pop() === heroName,
     );
-    if (!pending || !pending.get('url')) return null;
-
-    return { path: heroPath, url: pending.get('url') };
-  }
-
-  function loadImageDimensions(url) {
-    return new Promise((resolve, reject) => {
-      const img = new Image();
-      img.onload = () =>
-        resolve({ width: img.naturalWidth, height: img.naturalHeight });
-      img.onerror = () =>
-        reject(new Error('Could not load hero image for validation.'));
-      img.src = url;
-    });
+    return pending ? pending.get('url') : null;
   }
 
   function loadImageBlob(url) {
@@ -46,43 +32,15 @@
   CMS.registerEventListener({
     name: 'preSave',
     handler: async (event) => {
-      const resolved = await resolveHeroImageUrl(event.entry);
-      if (!resolved) return;
+      const url = resolveHeroImageUrl(event.entry);
+      if (!url) return;
 
-      const [dims, blob] = await Promise.all([
-        loadImageDimensions(resolved.url),
-        loadImageBlob(resolved.url),
-      ]);
+      const blob = await loadImageBlob(url);
 
-      const errors = [];
-      const path = resolved.path.toLowerCase();
-      const hasAllowedExt = HERO_LIMITS.allowedExtensions.some((ext) =>
-        path.endsWith(ext),
-      );
-      if (!hasAllowedExt) {
-        errors.push('Hero image must be a JPG/JPEG.');
-      }
-      if (
-        dims.width < HERO_LIMITS.minWidth ||
-        dims.height < HERO_LIMITS.minHeight
-      ) {
-        errors.push(
-          `Hero image is ${dims.width}×${dims.height}. Minimum is ${HERO_LIMITS.minWidth}×${HERO_LIMITS.minHeight}.`,
-        );
-      }
-      if (dims.width / dims.height < HERO_LIMITS.minAspectRatio) {
-        errors.push(
-          `Hero image (${dims.width}×${dims.height}) is too tall. Use a landscape image. width must be at least ${HERO_LIMITS.minAspectRatio}× height.`,
-        );
-      }
       if (blob.size > HERO_LIMITS.maxBytes) {
-        errors.push(
+        throw new Error(
           `Hero image is ${formatBytes(blob.size)}. Maximum is ${formatBytes(HERO_LIMITS.maxBytes)}. Please compress and re-upload.`,
         );
-      }
-
-      if (errors.length) {
-        throw new Error(errors.join('\n'));
       }
     },
   });

--- a/public/admin/scripts/hero-validation.js
+++ b/public/admin/scripts/hero-validation.js
@@ -1,8 +1,8 @@
 // preSave event listener that blocks Save when a pending heroImage upload
-// fails our constraints (format, file size). Only validates uploads that
-// haven't been committed yet — already-saved hero images are skipped. All
-// thresholds and matching error-message values come from HERO_LIMITS in
-// constants.js.
+// fails our constraints (format, decodability, file size). Only validates
+// uploads that haven't been committed yet — already-saved hero images are
+// skipped. All thresholds and matching error-message values come from
+// HERO_LIMITS in constants.js.
 
 (() => {
   const { HERO_LIMITS, formatBytes } = window.AdminHelpers;
@@ -24,11 +24,30 @@
     return { path: heroPath, url: pending.get('url') };
   }
 
+  function hasAllowedExtension(path) {
+    const lowerPath = path.toLowerCase();
+    return HERO_LIMITS.allowedExtensions.some((ext) =>
+      lowerPath.endsWith(ext),
+    );
+  }
+
   function loadImageBlob(url) {
     return fetch(url).then((response) => {
       if (!response.ok)
         throw new Error('Could not fetch hero image for validation.');
       return response.blob();
+    });
+  }
+
+  // Confirms the bytes are a real, decodable image — catches a corrupted
+  // upload or a non-image file that was merely renamed to .jpg, which the
+  // extension check alone can't detect.
+  function isDecodableImage(url) {
+    return new Promise((resolve) => {
+      const img = new Image();
+      img.onload = () => resolve(true);
+      img.onerror = () => resolve(false);
+      img.src = url;
     });
   }
 
@@ -38,24 +57,22 @@
       const resolved = resolveHeroImageUrl(event.entry);
       if (!resolved) return;
 
-      const blob = await loadImageBlob(resolved.url);
+      if (!hasAllowedExtension(resolved.path)) {
+        throw new Error('Hero image must be a JPG/JPEG.');
+      }
 
-      const errors = [];
-      const path = resolved.path.toLowerCase();
-      const hasAllowedExt = HERO_LIMITS.allowedExtensions.some((ext) =>
-        path.endsWith(ext),
-      );
-      if (!hasAllowedExt) {
-        errors.push('Hero image must be a JPG/JPEG.');
+      const [blob, decodable] = await Promise.all([
+        loadImageBlob(resolved.url),
+        isDecodableImage(resolved.url),
+      ]);
+
+      if (!decodable) {
+        throw new Error('Hero image could not be read as a valid image.');
       }
       if (blob.size > HERO_LIMITS.maxBytes) {
-        errors.push(
+        throw new Error(
           `Hero image is ${formatBytes(blob.size)}. Maximum is ${formatBytes(HERO_LIMITS.maxBytes)}. Please compress and re-upload.`,
         );
-      }
-
-      if (errors.length) {
-        throw new Error(errors.join('\n'));
       }
     },
   });


### PR DESCRIPTION
## Issue

Closes #48 

## Summary

Removes dimension and aspect-ratio limits on hero image uploads in Decap CMS, keeping only format and file-size checks.

## Changes

- Drop min width/height checks
- Drop landscape aspect-ratio check
- Keep JPG/JPEG format requirement
- Keep 800 KB max file size
- Update CMS hint text to match
